### PR TITLE
feat: Add trackball rotation feature

### DIFF
--- a/qmk_firmware/keyboards/hachiyuki/README.md
+++ b/qmk_firmware/keyboards/hachiyuki/README.md
@@ -1,0 +1,32 @@
+# Hachiyuki Keyboard
+
+This document describes the Hachiyuki keyboard, a custom mechanical keyboard featuring a trackball.
+
+## Features
+
+*   Integrated trackball (PAW3222 sensor)
+*   Powered by QMK firmware
+*   Configurable via Vial
+
+## Configuration
+
+The Hachiyuki keyboard offers several configuration options that can be adjusted by modifying the `keymaps/vial/config.h` file within the QMK firmware structure for this keyboard (`qmk_firmware/keyboards/hachiyuki/keymaps/vial/config.h`).
+
+### Trackball Rotation Angle (`TRACKBALL_ROTATION_ANGLE`)
+
+This setting allows you to rotate the perceived orientation of the trackball. This is useful if you mount or use the keyboard in a non-standard orientation.
+
+*   **Purpose**: Defines the clockwise rotation angle for the trackball sensor data.
+*   **File**: `qmk_firmware/keyboards/hachiyuki/keymaps/vial/config.h`
+*   **Supported Values**:
+    *   `0`: No rotation. This is the default behavior if the option is not defined or set to an unsupported value.
+    *   `90`: 90 degrees clockwise rotation. If you physically rotate your keyboard 90 degrees counter-clockwise (trackball on the left, pointing up), this setting will make the cursor respond as if the trackball is in its standard orientation. (Effectively, sensor X becomes -Y, and sensor Y becomes X).
+    *   `180`: 180 degrees clockwise rotation. (Sensor X becomes -X, sensor Y becomes -Y).
+    *   `270`: 270 degrees clockwise rotation. (Sensor X becomes Y, sensor Y becomes -X).
+*   **Default Behavior**: If `TRACKBALL_ROTATION_ANGLE` is not defined or is set to a value other than 90, 180, or 270, no rotation will be applied (equivalent to 0 degrees).
+
+To change the trackball rotation, open the specified `config.h` file and modify the `#define TRACKBALL_ROTATION_ANGLE` line to your desired value. For example, for a 90-degree rotation:
+```c
+#define TRACKBALL_ROTATION_ANGLE 90
+```
+After modifying the file, you will need to recompile and flash the firmware to your keyboard.

--- a/qmk_firmware/keyboards/hachiyuki/keymaps/vial/config.h
+++ b/qmk_firmware/keyboards/hachiyuki/keymaps/vial/config.h
@@ -8,3 +8,14 @@
 #define POINTING_DEVICE_RIGHT
 #define POINTING_DEVICE_INVERT_X
 #define POINTING_DEVICE_INVERT_Y
+
+/*
+ * Trackball Rotation Angle
+ * Defines the clockwise rotation angle for the trackball sensor data.
+ * Possible values:
+ *   0: No rotation (default behavior)
+ *   90: 90 degrees clockwise rotation (X becomes -Y, Y becomes X)
+ *   180: 180 degrees clockwise rotation (X becomes -X, Y becomes -Y)
+ *   270: 270 degrees clockwise rotation (X becomes Y, Y becomes -X)
+ */
+#define TRACKBALL_ROTATION_ANGLE 90

--- a/qmk_firmware/keyboards/hachiyuki/paw3222.c
+++ b/qmk_firmware/keyboards/hachiyuki/paw3222.c
@@ -19,6 +19,7 @@
 
 #include "pointing_device.h"
 
+#include "keymaps/vial/config.h" // For TRACKBALL_ROTATION_ANGLE
 #include "debug.h"
 #include "gpio.h"
 #include "paw3222.h"
@@ -174,8 +175,22 @@ report_mouse_t paw3222_get_report(report_mouse_t mouse_report) {
   if (data.isMotion) {
     pd_dprintf("Raw ] X: %d, Y: %d\n", data.x, data.y);
 
+#if defined(TRACKBALL_ROTATION_ANGLE) && TRACKBALL_ROTATION_ANGLE == 90
+    // 90 degrees clockwise rotation: X becomes -Y, Y becomes X
+    mouse_report.x = -data.y;
+    mouse_report.y = data.x;
+#elif defined(TRACKBALL_ROTATION_ANGLE) && TRACKBALL_ROTATION_ANGLE == 180
+    // 180 degrees clockwise rotation: X becomes -X, Y becomes -Y
+    mouse_report.x = -data.x;
+    mouse_report.y = -data.y;
+#elif defined(TRACKBALL_ROTATION_ANGLE) && TRACKBALL_ROTATION_ANGLE == 270
+    // 270 degrees clockwise rotation: X becomes Y, Y becomes -X
+    mouse_report.x = data.y;
+    mouse_report.y = -data.x;
+#else // Default to no rotation (0 degrees or undefined)
     mouse_report.x = data.x;
     mouse_report.y = data.y;
+#endif
   }
 
   return mouse_report;


### PR DESCRIPTION
This commit introduces a trackball rotation feature for the Hachiyuki keyboard.

The following changes were made:

1.  Modified `paw3222_get_report` in `qmk_firmware/keyboards/hachiyuki/paw3222.c` to support trackball rotation. The coordinates are transformed based on the `TRACKBALL_ROTATION_ANGLE` setting.
2.  Added a configuration option `TRACKBALL_ROTATION_ANGLE` in `qmk_firmware/keyboards/hachiyuki/keymaps/vial/config.h`. You can set this to 0, 90, 180, or 270 to rotate the trackball orientation.
3.  Created a new `README.md` file in `qmk_firmware/keyboards/hachiyuki/` with details about the keyboard and the new `TRACKBALL_ROTATION_ANGLE` configuration option.

This allows you to adjust the trackball behavior if the sensor is mounted in a rotated orientation.